### PR TITLE
Helm Chart

### DIFF
--- a/.github/workflows/lint-and-test-chart.yaml
+++ b/.github/workflows/lint-and-test-chart.yaml
@@ -1,0 +1,46 @@
+name: Lint and Test Charts
+
+on: pull_request
+
+jobs:
+  lint-test:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: ./deploy/chart
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+
+      - name: Set up Helm
+        uses: azure/setup-helm@v3
+        with:
+          version: v3.10.0
+
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.9'
+          check-latest: true
+
+      - name: Set up chart-testing
+        uses: helm/chart-testing-action@v2.3.1
+
+      - name: Run chart-testing (list-changed)
+        id: list-changed
+        run: |
+          changed=$(ct list-changed --target-branch ${{ github.event.repository.default_branch }})
+          if [[ -n "$changed" ]]; then
+            echo "::set-output name=changed::true"
+          fi
+
+      - name: Run chart-testing (lint)
+        run: ct lint --target-branch ${{ github.event.repository.default_branch }}
+
+      - name: Create kind cluster
+        uses: helm/kind-action@v1.4.0
+        if: steps.list-changed.outputs.changed == 'true'
+
+      - name: Run chart-testing (install)
+        run: ct install

--- a/.github/workflows/lint-and-test-chart.yaml
+++ b/.github/workflows/lint-and-test-chart.yaml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     defaults:
       run:
-        working-directory: ./deploy/chart
+        working-directory: ./deploy
     steps:
       - name: Checkout
         uses: actions/checkout@v2

--- a/.github/workflows/lint-and-test-chart.yaml
+++ b/.github/workflows/lint-and-test-chart.yaml
@@ -5,9 +5,6 @@ on: pull_request
 jobs:
   lint-test:
     runs-on: ubuntu-latest
-    defaults:
-      run:
-        working-directory: ./deploy
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -43,4 +40,4 @@ jobs:
         if: steps.list-changed.outputs.changed == 'true'
 
       - name: Run chart-testing (install)
-        run: ct install
+        run: ct install --chart-dirs deploy

--- a/deploy/chart/Chart.yaml
+++ b/deploy/chart/Chart.yaml
@@ -1,0 +1,4 @@
+apiVersion: v2
+name: hcloud-fip-controller
+version: 0.1.0
+appVersion: v0.1.0

--- a/deploy/chart/templates/cluser-role-binding.yaml
+++ b/deploy/chart/templates/cluser-role-binding.yaml
@@ -1,0 +1,12 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: fip-controller
+subjects:
+- kind: ServiceAccount
+  name: controller
+  namespace: {{.Release.Namespace}}
+roleRef:
+  kind: ClusterRole
+  name: fip-controller
+  apiGroup: rbac.authorization.k8s.io

--- a/deploy/chart/templates/cluser-role.yaml
+++ b/deploy/chart/templates/cluser-role.yaml
@@ -1,0 +1,8 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: fip-controller
+rules:
+- apiGroups: [""]
+  resources: ["nodes", "services"]
+  verbs: ["get", "watch", "list"]

--- a/deploy/chart/templates/deployment.yaml
+++ b/deploy/chart/templates/deployment.yaml
@@ -1,0 +1,23 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ .Chart.Name }}
+  labels:
+    app: {{ .Chart.Name }}
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: {{ .Chart.Name }}
+  template:
+    metadata:
+      labels:
+        app: {{ .Chart.Name }}
+    spec:
+      serviceAccountName: controller
+      containers:
+        - image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          name: {{ .Chart.Name }}
+          env:
+            - name: HCLOUD_TOKEN
+              value: {{ .Values.controller.secrets.hcloud_token }}

--- a/deploy/chart/templates/service-account.yaml
+++ b/deploy/chart/templates/service-account.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: ServiceAccount
+automountServiceAccountToken: true
+metadata:
+  name: controller
+  labels:
+    app: hcloud-fip-controller

--- a/deploy/chart/values.yaml
+++ b/deploy/chart/values.yaml
@@ -1,0 +1,7 @@
+image:
+  repository: ghcr.io/barodeur/hcloud-fip-controller
+  tag: ""
+
+controller:
+  secrets:
+    hcloud_token: ""


### PR DESCRIPTION
This adds a basic helm chart that includes:
- a service account with read access to `nodes` and `services` resources
- a deployment to run a single controller pod